### PR TITLE
Update to work with newer versions of rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,10 @@ First you'll need to setup a job for processing versions:
 ``` ruby
 # The class MUST be named this
 class VersionJob < ApplicationJob
-
-  # These are settings you'll probably want, I suggest sidekiq-unique-jobs
-  sidekiq_options(
-    :queue => "versions",
-    :unique_across_queues => true,
-    :lock => :until_executed,
-    :log_duplicate_payload => true
-  )
+  queue_as :default
 
   # This wires up the background job
-  include PaperTrail::Background::Sidekiq
+  include PaperTrail::Background::Job
 end
 ```
 

--- a/lib/paper_trail-background/rspec.rb
+++ b/lib/paper_trail-background/rspec.rb
@@ -1,6 +1,6 @@
 require 'ar_after_transaction'
 
-require_relative 'paper_trail/background/rspec_helpers'
+require_relative '../paper_trail/background/rspec_helpers'
 
 RSpec.configure do |config|
   config.include PaperTrail::Background::RSpecHelpers::InstanceMethods

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -1,4 +1,5 @@
 require "paper_trail/record_trail"
+require "ar_after_transaction"
 
 module PaperTrail
   require_relative "background/version"

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -2,7 +2,7 @@ require "paper_trail/record_trail"
 
 module PaperTrail
   require_relative "background/version"
-  require_relative "background/sidekiq"
+  require_relative "background/job"
 
   module Background
     # @api private
@@ -78,7 +78,7 @@ module PaperTrail
       version_class = record.class.paper_trail.version_class
 
       version_class.after_transaction do
-        VersionJob.perform_async(
+        VersionJob.perform_later(
           version_class,
           data,
           event

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -80,10 +80,7 @@ module PaperTrail
       version_class.after_transaction do
         VersionJob.perform_async(
           version_class,
-          data.merge(
-            :item_id => record.id,
-            :item_type => record.class.name
-          ),
+          data,
           event
         )
       end

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -1,3 +1,5 @@
+require "paper_trail/record_trail"
+
 module PaperTrail
   require_relative "background/version"
   require_relative "background/sidekiq"

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -75,7 +75,7 @@ module PaperTrail
     end
 
     private def trigger_write(record, data, event)
-      version_class = record.class.paper_trail.version_class
+      version_class = record.class.paper_trail.version_class.name
 
       version_class.after_transaction do
         VersionJob.perform_later(

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -77,7 +77,7 @@ module PaperTrail
     private def trigger_write(record, data, event)
       version_class = record.class.paper_trail.version_class.name
 
-      version_class.after_transaction do
+      ActiveRecord::Base.after_transaction do
         VersionJob.perform_later(
           version_class,
           data,

--- a/lib/paper_trail/background/job.rb
+++ b/lib/paper_trail/background/job.rb
@@ -1,6 +1,6 @@
 module PaperTrail
   module Background
-    module Sidekiq
+    module Job
       def perform(version_class, attributes, event)
         version = version_class.constantize.create!(attributes)
       end

--- a/lib/paper_trail/background/rspec_helpers.rb
+++ b/lib/paper_trail/background/rspec_helpers.rb
@@ -1,0 +1,43 @@
+module PaperTrail
+  module Background
+    module RSpecHelpers
+      module InstanceMethods
+        # enable versioning for specific blocks (at instance-level)
+        def with_versioning(&block)
+          was_enabled = ::PaperTrail.enabled?
+          ::PaperTrail.enabled = true
+
+          normally_open_transactions = ActiveRecord::Base.normally_open_transactions
+          ActiveRecord::Base.normally_open_transactions = 2
+
+          # ensure that VersionJobs are executed
+          perform_enqueued_jobs only: VersionJob, &block
+        ensure
+          ::PaperTrail.enabled = was_enabled
+          ActiveRecord::Base.normally_open_transactions = normally_open_transactions
+        end
+      end
+
+      module ClassMethods
+        # enable versioning for specific blocks (at class-level)
+        def with_versioning(&block)
+          context "with versioning", versioning: true do
+            around do |example|
+              normally_open_transactions = ActiveRecord::Base.normally_open_transactions
+              ActiveRecord::Base.normally_open_transactions = 2
+
+              perform_enqueued_jobs only: VersionJob do
+                example.run
+              end
+
+              ActiveRecord::Base.normally_open_transactions = normally_open_transactions
+            end
+
+            class_exec(&block)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/paper_trail/background/rspec_helpers.rb
+++ b/lib/paper_trail/background/rspec_helpers.rb
@@ -3,12 +3,12 @@ module PaperTrail
     module RSpecHelpers
       module InstanceMethods
         # enable versioning for specific blocks (at instance-level)
-        def with_versioning(&block)
+        def with_versioning(expected_open_transactions: 1, &block)
           was_enabled = ::PaperTrail.enabled?
           ::PaperTrail.enabled = true
 
           normally_open_transactions = ActiveRecord::Base.normally_open_transactions
-          ActiveRecord::Base.normally_open_transactions = 2
+          ActiveRecord::Base.normally_open_transactions = expected_open_transactions
 
           # ensure that VersionJobs are executed
           perform_enqueued_jobs only: VersionJob, &block
@@ -20,11 +20,11 @@ module PaperTrail
 
       module ClassMethods
         # enable versioning for specific blocks (at class-level)
-        def with_versioning(&block)
+        def with_versioning(expected_open_transactions: 1, &block)
           context "with versioning", versioning: true do
             around do |example|
               normally_open_transactions = ActiveRecord::Base.normally_open_transactions
-              ActiveRecord::Base.normally_open_transactions = 2
+              ActiveRecord::Base.normally_open_transactions = expected_open_transactions
 
               perform_enqueued_jobs only: VersionJob do
                 example.run

--- a/lib/paper_trail/background/version.rb
+++ b/lib/paper_trail/background/version.rb
@@ -1,5 +1,5 @@
 module PaperTrail
   module Background
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/lib/rspec.rb
+++ b/lib/rspec.rb
@@ -3,6 +3,6 @@ require 'ar_after_transaction'
 require_relative 'paper_trail/background/rspec_helpers'
 
 RSpec.configure do |config|
-  config.include PaperTrailBackgroundRspecHelpers::InstanceMethods
-  config.extend PaperTrailBackgroundRspecHelpers::ClassMethods
+  config.include PaperTrail::Background::RSpecHelpers::InstanceMethods
+  config.extend PaperTrail::Background::RSpecHelpers::ClassMethods
 end

--- a/lib/rspec.rb
+++ b/lib/rspec.rb
@@ -1,0 +1,8 @@
+require 'ar_after_transaction'
+
+require_relative 'paper_trail/background/rspec_helpers'
+
+RSpec.configure do |config|
+  config.include PaperTrailBackgroundRspecHelpers::InstanceMethods
+  config.extend PaperTrailBackgroundRspecHelpers::ClassMethods
+end

--- a/paper_trail-background.gemspec
+++ b/paper_trail-background.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "0.11.2"
   spec.add_development_dependency "pry-doc", "0.11.1"
   spec.add_runtime_dependency "ar_after_transaction", "0.5.0"
-  spec.add_runtime_dependency "paper_trail", "10.0.1"
+  spec.add_runtime_dependency "paper_trail", ">= 10.0.1"
 end

--- a/paper_trail-background.gemspec
+++ b/paper_trail-background.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "pry", "0.11.2"
   spec.add_development_dependency "pry-doc", "0.11.1"
-  spec.add_runtime_dependency "ar_after_transaction", "0.5.0"
+  spec.add_runtime_dependency "ar_after_transaction", "~> 0.8.0"
   spec.add_runtime_dependency "paper_trail", ">= 10.0.1"
 end

--- a/paper_trail-background.gemspec
+++ b/paper_trail-background.gemspec
@@ -1,5 +1,4 @@
-$:.push File.expand_path(File.join("..", "lib"), __FILE__)
-require "paper_trail-background"
+require_relative "lib/paper_trail/background/version"
 
 Gem::Specification.new do |spec|
   spec.name = "paper_trail-background"


### PR DESCRIPTION
Hello 👋

My colleagues found this gem (and the gist it originated from), and we wanted to start using it for our own use-cases. It needed some work to get it up to working with current-gen Rails/AR (~7) and ActiveJob. Contributing these changes back in case you want them 🙂

- Changed semantics from Sidekiq-specific to ActiveJob (e.g. `perform_async` -> `perform_later`)
- Updated pinned versions/let versions be flexible (could probably raise the PaperTrail version to be 12.x.x, since that's the version we've been using)
- Newer versions of PaperTrail do not need to explicitly have the item id and type set; this is done by the Event object code.