### PR TITLE
Add configuration and opt-in behavior, update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ class VersionJob < ApplicationJob
 end
 ```
 
+## Configuration
+In an initializer, you can specify whether you want to opt into this behavior on a per-model basis:
+
+``` ruby
+PaperTrail::Background::Config.configure do |config|
+  config.opt_in = true
+end
+```
+
+If opt-in behavior is set to `true`, you can enable async paper trails by specifying `async: true` in a given model's paper trail options:
+
+``` ruby
+class SomeModel < ActiveRecord::Base
+  has_paper_trail async: true
+end
+```
 
 ## Installing
 

--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -2,6 +2,7 @@ require "paper_trail/record_trail"
 require "ar_after_transaction"
 
 module PaperTrail
+  require_relative "background/config"
   require_relative "background/version"
   require_relative "background/job"
 
@@ -11,6 +12,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_create
       return unless enabled?
+      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
 
       event = PaperTrail::Events::Create.new(@record, true)
 
@@ -28,6 +30,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_destroy(recording_order)
       return unless enabled?
+      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
       return if @record.new_record?
 
       in_after_callback = recording_order == "after"
@@ -46,6 +49,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_update(force:, in_after_callback:, is_touch:)
       return unless enabled?
+      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
 
       event = PaperTrail::Events::Update.new(@record, in_after_callback, is_touch, nil)
 
@@ -63,6 +67,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_update_columns(changes)
       return unless enabled?
+      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
 
       event = Events::Update.new(@record, false, false, changes)
 

--- a/lib/paper_trail/background/config.rb
+++ b/lib/paper_trail/background/config.rb
@@ -1,0 +1,23 @@
+module PaperTrail
+  module Background
+    class Configuration
+      attr_reader :opt_in
+
+      def opt_in=(value)
+        @opt_in = value
+      end
+    end
+
+    class Config
+      class << self
+        def configuration
+          @configuration ||= Configuration.new
+        end
+
+        def configure(&block)
+          yield(configuration)
+        end
+      end
+    end
+  end
+end

--- a/paper_trail-background.gemspec
+++ b/paper_trail-background.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir[File.join("lib", "**", "*"), "LICENSE", "README.md", "Rakefile"]
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rake", "~> 12.2"
-  spec.add_development_dependency "pry", "0.11.2"
+  spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "pry-doc", "0.11.1"
   spec.add_runtime_dependency "ar_after_transaction", "~> 0.8.0"
   spec.add_runtime_dependency "paper_trail", ">= 10.0.1"

--- a/spec/background_spec.rb
+++ b/spec/background_spec.rb
@@ -1,0 +1,200 @@
+require "spec_helper"
+
+class DummyClass
+  include PaperTrail::Background
+
+  def initialize(options: {}, record: nil)
+    @options = options
+    @record = record
+  end
+
+  def enabled?
+    @options[:enabled]
+  end
+
+  def data_for_create
+    {}
+  end
+
+  def data_for_destroy
+    {}
+  end
+
+  def data_for_update_columns
+    {}
+  end
+
+  def force
+    true
+  end
+end
+
+class VersionJob
+  def self.perform_later(*args); end
+end
+
+RSpec.describe PaperTrail::Background do
+  before do
+    allow(VersionJob).to receive(:perform_later)
+  end
+
+  describe "#record_create" do
+    it "does not trigger a write if not enabled" do
+      DummyClass.new(options: { enabled: false }).record_create
+
+      expect(VersionJob).not_to have_received(:perform_later)
+    end
+
+    context "when enabled and opt_in config is enabled" do
+      let(:record) { double("SomeRecord") }
+
+      before do
+        PaperTrail::Background::Config.configure do |config|
+          config.opt_in = true
+        end
+      end
+
+      it "does not trigger a write if record is opted in but async is blank" do
+        allow(record).to receive(:paper_trail_options).and_return(async: nil)
+
+        DummyClass.new(options: { enabled: true }, record: record).record_create
+
+        expect(VersionJob).not_to have_received(:perform_later)
+      end
+
+      it "triggers a write if record is opted in and async is true" do
+        allow(record).to receive(:paper_trail_options).and_return(async: true)
+        allow(PaperTrail::Events::Create).to receive(:new).and_return(OpenStruct.new(data: {}))
+        allow(RSpec::Mocks::Double).to receive(:paper_trail).and_return(OpenStruct.new(version_class: Class))
+        allow(ActiveRecord::Base).to receive(:after_transaction).and_yield
+
+        DummyClass.new(options: { enabled: true }, record: record).record_create
+
+        expect(VersionJob).to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe "#record_destroy" do
+    it "does not trigger a write if not enabled" do
+      DummyClass.new(options: { enabled: false }).record_destroy("after")
+
+      expect(VersionJob).not_to have_received(:perform_later)
+    end
+
+    context "when enabled and opt_in config is enabled" do
+      let(:record) { double("SomeRecord") }
+
+      before do
+        PaperTrail::Background::Config.configure do |config|
+          config.opt_in = true
+        end
+      end
+
+      it "does not trigger a write if record is opted in but async is blank" do
+        allow(record).to receive(:paper_trail_options).and_return(async: nil)
+
+        DummyClass.new(options: { enabled: true }, record: record).record_destroy("after")
+
+        expect(VersionJob).not_to have_received(:perform_later)
+      end
+
+      it "does not trigger a write if record is new" do
+        allow(record).to receive(:paper_trail_options).and_return(async: true)
+        allow(record).to receive(:new_record?).and_return(true)
+
+        DummyClass.new(options: { enabled: true }, record: record).record_destroy("after")
+
+        expect(VersionJob).not_to have_received(:perform_later)
+      end
+
+      it "triggers a write if record is opted in and async is true" do
+        allow(record).to receive(:paper_trail_options).and_return(async: true)
+        allow(record).to receive(:new_record?).and_return(false)
+        allow(PaperTrail::Events::Destroy).to receive(:new).and_return(OpenStruct.new(data: {}))
+        allow(RSpec::Mocks::Double).to receive(:paper_trail).and_return(OpenStruct.new(version_class: Class))
+        allow(ActiveRecord::Base).to receive(:after_transaction).and_yield
+
+        DummyClass.new(options: { enabled: true }, record: record).record_destroy("after")
+
+        expect(VersionJob).to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe "#record_update" do
+    it "does not trigger a write if not enabled" do
+      DummyClass.new(options: { enabled: false }).record_update(force: true, in_after_callback: true, is_touch: false)
+
+      expect(VersionJob).not_to have_received(:perform_later)
+    end
+
+    context "when enabled and opt_in config is enabled" do
+      let(:record) { double("SomeRecord") }
+
+      before do
+        PaperTrail::Background::Config.configure do |config|
+          config.opt_in = true
+        end
+      end
+
+      it "does not trigger a write if record is opted in but async is blank" do
+        allow(record).to receive(:paper_trail_options).and_return(async: nil)
+
+        DummyClass.new(options: { enabled: true }, record: record).record_update(force: true, in_after_callback: true, is_touch: false)
+
+        expect(VersionJob).not_to have_received(:perform_later)
+      end
+
+      it "triggers a write if record is opted in and async is true" do
+        allow(record).to receive(:paper_trail_options).and_return(async: true)
+        allow(record).to receive(:new_record?).and_return(false)
+        allow(PaperTrail::Events::Update).to receive(:new).and_return(OpenStruct.new(data: {}))
+        allow(RSpec::Mocks::Double).to receive(:paper_trail).and_return(OpenStruct.new(version_class: Class))
+        allow(ActiveRecord::Base).to receive(:after_transaction).and_yield
+
+        DummyClass.new(options: { enabled: true }, record: record).record_update(force: true, in_after_callback: true, is_touch: false)
+
+        expect(VersionJob).to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe "#record_update_columns" do
+    it "does not trigger a write if not enabled" do
+      DummyClass.new(options: { enabled: false }).record_update_columns({})
+
+      expect(VersionJob).not_to have_received(:perform_later)
+    end
+
+    context "when enabled and opt_in config is enabled" do
+      let(:record) { double("SomeRecord") }
+
+      before do
+        PaperTrail::Background::Config.configure do |config|
+          config.opt_in = true
+        end
+      end
+
+      it "does not trigger a write if record is opted in but async is blank" do
+        allow(record).to receive(:paper_trail_options).and_return(async: nil)
+
+        DummyClass.new(options: { enabled: true }, record: record).record_update_columns({})
+
+        expect(VersionJob).not_to have_received(:perform_later)
+      end
+
+      it "triggers a write if record is opted in and async is true" do
+        allow(record).to receive(:paper_trail_options).and_return(async: true)
+        allow(record).to receive(:new_record?).and_return(false)
+        allow(PaperTrail::Events::Update).to receive(:new).and_return(OpenStruct.new(data: {}))
+        allow(RSpec::Mocks::Double).to receive(:paper_trail).and_return(OpenStruct.new(version_class: Class))
+        allow(ActiveRecord::Base).to receive(:after_transaction).and_yield
+
+        DummyClass.new(options: { enabled: true }, record: record).record_update_columns({})
+
+        expect(VersionJob).to have_received(:perform_later)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds the option to opt into async behavior for PaperTrail through a Config class that can be used in an initializer. The rationale is some users of this gem may only want to make PaperTrail async on a case by case basis for some models.

Initializer can be used like so:

```rb
PaperTrail::Background::Config.configure do |config|
  config.opt_in = true
end
```

This gem's behavior can then be enabled on a specific model like so:
```rb
class SomeModel < ActiveRecord::Base
  has_paper_trail async: true
end
```

This change maintains the contract this gem already had by keeping the behavior async for all models unless this configuration is specifically turned on.

I also bumped the `bundler` and `pry` dependencies to more recent versions and added some tests around the opt in behavior.