### PR TITLE
Return super if not async

### DIFF
--- a/lib/paper_trail/background.rb
+++ b/lib/paper_trail/background.rb
@@ -12,7 +12,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_create
       return unless enabled?
-      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
+      return super if @record.paper_trail_options[:async].blank?
 
       event = PaperTrail::Events::Create.new(@record, true)
 
@@ -30,7 +30,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_destroy(recording_order)
       return unless enabled?
-      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
+      return super if @record.paper_trail_options[:async].blank?
       return if @record.new_record?
 
       in_after_callback = recording_order == "after"
@@ -49,7 +49,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_update(force:, in_after_callback:, is_touch:)
       return unless enabled?
-      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
+      return super if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
 
       event = PaperTrail::Events::Update.new(@record, in_after_callback, is_touch, nil)
 
@@ -67,7 +67,7 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_update_columns(changes)
       return unless enabled?
-      return if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
+      return super if Config.configuration.opt_in && @record.paper_trail_options[:async].blank?
 
       event = Events::Update.new(@record, false, false, changes)
 


### PR DESCRIPTION
**Expected behavior:** 
When a model does not include `async: true` and `Config.configuration.opt_in` is enabled, papertrail is handled synchronously. 

**Solution:**
Because we are using `prepend` to `PaperTrail::RecordTrail` we need to be sure to return `super` when we do not want a model to be async. 