### PR TITLE
Rails 7.2 support

### DIFF
--- a/paper_trail-background.gemspec
+++ b/paper_trail-background.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir[File.join("lib", "**", "*"), "LICENSE", "README.md", "Rakefile"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ar_after_transaction", "~> 0.10.0"
+  spec.add_runtime_dependency "ar_after_transaction", "~> 0.12.0"
   spec.add_runtime_dependency "paper_trail", ">= 10"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
`ar_after_transaction` adds support for Rails 7.2 in [v0.12.0](https://github.com/grosser/ar_after_transaction/pull/42)
